### PR TITLE
Made the token take from environment variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/__pycache__
+.env

--- a/constant.py
+++ b/constant.py
@@ -1,4 +1,7 @@
-# TODO remove token before commit
-TOKEN = "TOKEN"
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+TOKEN = os.environ['TOKEN'] # create a file called '.env' and put token there. Needs python-dotenv package
 
 BASE_URL = "https://api.github.com/"


### PR DESCRIPTION
Added a gitignore and made the constant file take the token from environment variables instead of being in plaintext. This is to make it easier and ensures we do not accidentally commit our github tokens. 